### PR TITLE
Making DNS timeout non fatal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 *.idea
+.vscode
 
 # Test binary, built with `go test -c`
 *.test

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -83,8 +83,8 @@ func (r *Runner) process() error {
 		case asnmap.Domain:
 			resolvedIps, err := asnmap.ResolveDomain(item, r.options.Resolvers...)
 			if err != nil {
-				errProcess = err
-				return err
+				gologger.Verbose().Msgf("could not resolve '%s': %v", item, err)
+				return nil
 			}
 
 			if len(resolvedIps) == 0 {


### PR DESCRIPTION
# Closes #101 #92

```console
$ go run . -d tttttt.tototototo -v

   ___   _____  __
  / _ | / __/ |/ /_ _  ___ ____
 / __ |_\ \/    /  ' \/ _  / _ \
/_/ |_/___/_/|_/_/_/_/\_,_/ .__/
                         /_/

                projectdiscovery.io

[INF] Current asnmap version v1.0.3 (latest)
[VER] could not resolve 'tttttt.tototototo': EOF
```