### PR TITLE
fix CSV stdout

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -58,10 +58,7 @@ func (r *Runner) Run() error {
 		outputWriters = append(outputWriters, file)
 	}
 
-	if !r.options.DisplayInCSV {
-		outputWriters = append(outputWriters, os.Stdout)
-	}
-
+	outputWriters = append(outputWriters, os.Stdout)
 	r.options.Output = io.MultiWriter(outputWriters...)
 
 	if r.options.DisplayInCSV {


### PR DESCRIPTION
Closes #302

before:
```console
go run . -a AS20001 -c

   ___   _____  __              
  / _ | / __/ |/ /_ _  ___ ____ 
 / __ |_\ \/    /  ' \/ _  / _ \
/_/ |_/___/_/|_/_/_/_/\_,_/ .__/
                         /_/ 

                projectdiscovery.io

[INF] Current asnmap version v1.1.0 (latest)
```


after:
```console
$ go run . -a AS20001 -c 

   ___   _____  __              
  / _ | / __/ |/ /_ _  ___ ____ 
 / __ |_\ \/    /  ' \/ _  / _ \
/_/ |_/___/_/|_/_/_/_/\_,_/ .__/
                         /_/ 

                projectdiscovery.io

[INF] Current asnmap version v1.1.0 (latest)
timestamp|input|as_number|as_name|as_country|as_range
2024-03-12 20:35:19.489137 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|23.177.64.0/24
2024-03-12 20:35:19.48925 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|23.240.0.0/14
2024-03-12 20:35:19.489258 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|24.24.128.0/17
2024-03-12 20:35:19.489265 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|24.25.192.0/18
2024-03-12 20:35:19.489272 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|24.30.128.0/18
2024-03-12 20:35:19.489277 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|24.43.0.0/17,24.43.128.0/19,24.43.160.0/20,24.43.176.0/21
2024-03-12 20:35:19.48933 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|24.43.192.0/19,24.43.224.0/20
2024-03-12 20:35:19.489347 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|24.43.240.0/21,24.43.248.0/23
2024-03-12 20:35:19.489367 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|24.43.250.0/23,24.43.252.0/22
2024-03-12 20:35:19.48941 +0300 +03|AS20001|AS20001|twc-20001-pacwest|US|24.94.0.0/19
...
```